### PR TITLE
Upgrade isort

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-install_requires = ['isort>=4.1.1,<5']
+install_requires = ['isort>=4.3.16,<5']
 if sys.version_info < (2, 7):
     install_requires.append('argparse')
 


### PR DESCRIPTION
## Problem
isort throws warnings that it is misconfigured if it doesn't see itself inside `pyproject.toml`, even though its config lives in `setup.cfg`

## Solution
Upgrade isort to the version where they fixed this warning, so it will only through if it sees a misconfigured `pyproject.toml` if its config lives in that file.